### PR TITLE
[mysql] fix replication for 5.5

### DIFF
--- a/5.5/init-slave.sh
+++ b/5.5/init-slave.sh
@@ -31,6 +31,8 @@ mysql -u root -e "RESET MASTER; \
   MASTER_USER='$REPLICATION_USER', \
   MASTER_PASSWORD='$REPLICATION_PASSWORD';"
 
+sleep 5
+
 mysqldump \
   --protocol=tcp \
   --user=$REPLICATION_USER \

--- a/5.5/replication-entrypoint.sh
+++ b/5.5/replication-entrypoint.sh
@@ -43,8 +43,6 @@ else
   cat > /etc/mysql/conf.d/repl-slave.cnf << EOF
 [mysqld]
 log-slave-updates
-master-info-repository=TABLE
-relay-log-info-repository=TABLE
 relay-log-recovery=1
 EOF
 fi


### PR DESCRIPTION
Modified the configuration for 5.5, as the `master-info-repository` and `relay-log-info-repository` options do not exist on 5.5 (they defaulted to files).

I also had to setup a sleep after modifying the master status on the slave, there seems to be a race condition there. Other than that, it all worked as advertised.